### PR TITLE
Simplest solution to exit when shell task exits

### DIFF
--- a/features/run.feature
+++ b/features/run.feature
@@ -303,3 +303,20 @@ Scenario: Command in task exits with non-zero code
   hello after exit 1
 
   """
+
+
+Scenario: Command in task exits with non-zero code when set -e is in effect
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+   test: |
+       set -e
+       bash -c 'exit 1'
+       echo "hello after exit 1"
+    """
+  When I run "oya run test"
+  Then the command fails with error matching
+    """
+    task exited with code 1
+    """

--- a/features/run.feature
+++ b/features/run.feature
@@ -272,3 +272,17 @@ Scenario: Allow empty Require, Import: Values
   hello from foo
 
   """
+
+Scenario: Commands exits with non-zero code
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+   test: |
+       exit 1
+    """
+  When I run "oya run test"
+  Then the command fails with error matching
+    """
+    task exited with code 1
+    """

--- a/features/run.feature
+++ b/features/run.feature
@@ -273,7 +273,7 @@ Scenario: Allow empty Require, Import: Values
 
   """
 
-Scenario: Commands exits with non-zero code
+Scenario: Task exits with non-zero code
   Given file ./Oyafile containing
     """
     Project: project
@@ -286,3 +286,20 @@ Scenario: Commands exits with non-zero code
     """
     task exited with code 1
     """
+
+Scenario: Command in task exits with non-zero code
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+   test: |
+       bash -c 'exit 1'
+       echo "hello after exit 1"
+    """
+  When I run "oya run test"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  hello after exit 1
+
+  """

--- a/pkg/task/script.go
+++ b/pkg/task/script.go
@@ -46,11 +46,6 @@ func (s Script) Exec(workDir string, args []string, values template.Scope, stdou
 		switch err.(type) {
 		case nil:
 		case interp.ExitStatus:
-			errCode := err.(interp.ExitStatus)
-			if errCode != 0 {
-				return fmt.Errorf("task exited with code %d", errCode)
-			}
-			return nil
 		case interp.ShellExitStatus:
 			errCode := err.(interp.ShellExitStatus)
 			if errCode != 0 {

--- a/pkg/task/script.go
+++ b/pkg/task/script.go
@@ -45,8 +45,15 @@ func (s Script) Exec(workDir string, args []string, values template.Scope, stdou
 		err := r.Run(ctx, stmt)
 		switch err.(type) {
 		case nil:
+			// Continue with next statement in script.
 		case interp.ExitStatus:
+			// Sub-command exited.
+			// Disregard, as either:
+			//   - "set -e" is in effect -> and shell will exit if needed,
+			//   - or not -> and exit status should be ignored anyway
 		case interp.ShellExitStatus:
+			// Shell interpreter exited.
+			// Either early return (due to "exit" or "set -e"), or task is finished.
 			errCode := err.(interp.ShellExitStatus)
 			if errCode != 0 {
 				return fmt.Errorf("task exited with code %d", errCode)


### PR DESCRIPTION
A couple of questions:
~1. Should we treat `interp.ExitStatus` the same way as `interp.ShellExitStatus`? I think they are meant to represent different class of errors, but I fail to understand it from documentation.~ Found and fixed.
2. Right now the exit code is always 1 - a good practice would be to propagate somehow shell exit code. This'd require some tinkering, as I don't think calling `os.Exit` in `Script.Run` is the prettiest solution.
3. Right now the error is pretty-printed, resulting in a stack trace and prefix to Oyafile. Dunno if it's ok ;)

Somewhat closes https://github.com/tooploox/oya/issues/37.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tooploox/oya/38)
<!-- Reviewable:end -->
