### PR TITLE
Fix installer: choose amd64 for x86_64 darwin arch

### DIFF
--- a/docs/get
+++ b/docs/get
@@ -36,9 +36,9 @@ get_os() {
 
 get_arch() {
     archstr=`uname -m`
-    if [[ "$archstr" == 'x86_64' || "$archstr" == 'x86' ]]; then
+    if [[ "$archstr" == 'x86' ]]; then
         arch='386'
-    elif [[ "$archstr" == 'AMD64' ]]; then
+    elif [[ "$archstr" == 'x86_64' || "$archstr" == 'AMD64' ]]; then
          arch='amd64'
     else
         echo "Sorry Oya doesn't support ${archstr} architecture yet! :("


### PR DESCRIPTION
bugfix for dawrin x86_64 was installing 386 build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tooploox/oya/41)
<!-- Reviewable:end -->
